### PR TITLE
use closure with spread syntax instead of Function.prototype.bind

### DIFF
--- a/src/inpage.mjs
+++ b/src/inpage.mjs
@@ -20,7 +20,7 @@ export async function inPageRoutine (randomToken, hostOverride) {
   */
 
   const hostAPI = ['getETLDP1'].reduce((acc, v) => {
-    acc[v] = window[randomToken].bind(null, v)
+    acc[v] = (...args) => window[randomToken](v, ...args)
     return acc
   }, {})
 


### PR DESCRIPTION
This will be more robust against pages which, for whatever reason, override `Function.prototype.bind`