### PR TITLE
renovate: ignore testcases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,16 @@
       "matchUpdateTypes": ["major"],
       "enabled": true
     }
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/testcases/**",
+    "**/__fixtures__/**"
   ]
 }


### PR DESCRIPTION
This PR extends `ignorePaths` (based on the `config:recommended` preset) with the `testcases` directory.