### PR TITLE
Restore --disable-component-update default Puppeteer arg

### DIFF
--- a/src/puppeteer.mjs
+++ b/src/puppeteer.mjs
@@ -10,7 +10,8 @@ export const puppeteerConfigForArgs = async (args) => {
       '--no-sandbox',
       '--disable-setuid-sandbox',
       '--disable-gpu',
-      '--disable-features=BraveAdblockCookieListDefault,BraveAdblockMobileNotificationsListDefault'
+      '--disable-features=BraveAdblockCookieListDefault,BraveAdblockMobileNotificationsListDefault',
+      '--disable-component-update'
     ],
     executablePath: args.executablePath,
     ignoreDefaultArgs: [


### PR DESCRIPTION
`--disable-component-update` was removed from the default args in puppeteer-core [v23.6.0](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v23.6.0), this PR restores the previous behaviour.


> The --disable-component-update command-line flag does two things: it disables component updates (desired) but it also prevents any bundled components from being initialized (undesired).

This flag disables bundled components (`MEIPreload`, etc), adblock components are still registered.