### PR TITLE
Wait for page loads to finish before proceeding with inpage script

### DIFF
--- a/src/inpage.mjs
+++ b/src/inpage.mjs
@@ -24,6 +24,12 @@ export async function inPageRoutine (randomToken, hostOverride) {
     return acc
   }, {})
 
+  await new Promise(resolve => {
+    window.onload = () => {
+      resolve()
+    }
+  })
+
   const fixedPositionElements = []
   const walker = document.createTreeWalker(
     document.documentElement,


### PR DESCRIPTION
resolves issues like "Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'."