### PR TITLE
fix: add '--allow-brave-component-update' flag

### DIFF
--- a/src/puppeteer.mjs
+++ b/src/puppeteer.mjs
@@ -11,6 +11,7 @@ export const puppeteerConfigForArgs = async (args) => {
       '--disable-setuid-sandbox',
       '--disable-gpu',
       '--disable-features=BraveAdblockCookieListDefault,BraveAdblockMobileNotificationsListDefault',
+      '--allow-brave-component-update',
       '--disable-component-update'
     ],
     executablePath: args.executablePath,


### PR DESCRIPTION
https://github.com/brave/brave-core/pull/30440 fixed the `--disable-component-update` handling for brave components, `--allow-brave-component-update` restores the previous behavior.

Related: https://github.com/brave/cookiecrumbler/pull/95