### PR TITLE
use `tree-walker-shadow-dom`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "@reporters/github": "1.12.0",
         "esbuild": "0.27.4",
         "eslint": "9.39.4",
-        "neostandard": "0.12.2"
+        "neostandard": "0.12.2",
+        "tree-walker-shadow-dom": "^1.0.0"
       }
     },
     "node_modules/@actions/core": {
@@ -7861,6 +7862,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tree-walker-shadow-dom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tree-walker-shadow-dom/-/tree-walker-shadow-dom-1.0.0.tgz",
+      "integrity": "sha512-pJwkYvkSHULktnGegaPczF0kcWxtFYj7+rkveecNYWkWP3A0RkeLS8W8af0KS3gD4LsgvY37kTt7PVnHXvhbDA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@reporters/github": "1.12.0",
     "esbuild": "0.27.4",
     "eslint": "9.39.4",
-    "neostandard": "0.12.2"
+    "neostandard": "0.12.2",
+    "tree-walker-shadow-dom": "^1.0.0"
   }
 }

--- a/src/inpage/index.mjs
+++ b/src/inpage/index.mjs
@@ -1,4 +1,5 @@
 import { generateRandomToken } from '../util.mjs'
+import createTreeWalker from 'tree-walker-shadow-dom'
 
 const windowRect = {
   left: 0,
@@ -13,7 +14,7 @@ const windowRect = {
  */
 const collectMatchingElements = (criteria) => {
   const elements = []
-  const walker = document.createTreeWalker(
+  const walker = createTreeWalker(
     document.documentElement,
     NodeFilter.SHOW_ELEMENT,
     e => criteria(e) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP


### PR DESCRIPTION
Inspired by a shadow-DOM-isolated cookie notice on https://villagehatshop.com. This change allows the cookie notice to be detected, assuming the timeout is increased to match the >4 second wait period for the notice to become available.

Sadly, I couldn't add the site as a test case because shadow DOMs don't serialize correctly, but the library is well-tested.