### PR TITLE
Problematic Overlay on a page is visible through reports and API

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -537,6 +537,12 @@ details pre {
           card.appendChild(p);
         }
 
+        if (report.problematicOverlay === true) {
+          const p = document.createElement('p');
+          p.textContent = '⚠️ A "problematic overlay" was detected on this page.';
+          card.appendChild(p);
+        }
+
         if (report.unsupportedBrowser === true) {
           const p = document.createElement('p');
           p.textContent = '🚫 An "unsupported browser" message was detected on this page.';

--- a/src/inpage/index.mjs
+++ b/src/inpage/index.mjs
@@ -283,6 +283,10 @@ export async function inPageRoutine (randomToken, hostOverride) {
   stylesheet.textContent = '.' + hideClass + ' { display: none !important }'
   document.head.appendChild(stylesheet)
 
+  // Detect if there is a full-page overlay that contains no text. This is likely due to a cookie notice that is hidden, without the overlay being removed. 
+  // This is a common issue on some sites, and can block interaction with the page.
+  let problematicOverlay = findProblematicOverlay()
+
   // Scroll blocking detection
   let scrollBlocked = false
   if (document.querySelectorAll('dialog[open]').length === 0) {
@@ -290,7 +294,7 @@ export async function inPageRoutine (randomToken, hostOverride) {
       getComputedStyle(document.documentElement).overflowY === 'hidden') {
       // Scroll is blocked. This could be intentional if there's an actionable popup in front of it,
       // but if there's an empty overlay at the front of the page, it's almost certainly an issue.
-      if (findProblematicOverlay()) {
+      if (problematicOverlay) {
         scrollBlocked = true
       }
     }
@@ -315,6 +319,7 @@ export async function inPageRoutine (randomToken, hostOverride) {
     cookieNotices: identifiedCookieNotices,
     classifiersUsed: Array.from(classifiersUsed).sort(),
     scrollBlocked,
+    problematicOverlay,
     unsupportedBrowser,
     url: window.location.href,
   }

--- a/src/inpage/index.mjs
+++ b/src/inpage/index.mjs
@@ -283,9 +283,9 @@ export async function inPageRoutine (randomToken, hostOverride) {
   stylesheet.textContent = '.' + hideClass + ' { display: none !important }'
   document.head.appendChild(stylesheet)
 
-  // Detect if there is a full-page overlay that contains no text. This is likely due to a cookie notice that is hidden, without the overlay being removed. 
+  // Detect if there is a full-page overlay that contains no text. This is likely due to a cookie notice that is hidden, without the overlay being removed.
   // This is a common issue on some sites, and can block interaction with the page.
-  let problematicOverlay = findProblematicOverlay()
+  const problematicOverlay = findProblematicOverlay()
 
   // Scroll blocking detection
   let scrollBlocked = false

--- a/src/lib.mjs
+++ b/src/lib.mjs
@@ -306,6 +306,7 @@ export const checkPage = async (args) => {
       }
       report.scrollBlocked = ((await inPageResult.evaluate(r => r.scrollBlocked)) === true)
       report.unsupportedBrowser = (await inPageResult.evaluate(r => r.unsupportedBrowser)) ?? null
+      report.problematicOverlay = (await inPageResult.evaluate(r => r.problematicOverlay)) ?? null
     } catch (err) {
       report.error = err.stack
     } finally {

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -24,7 +24,7 @@ const args = {
 const CONCURRENCY = Math.max(1, Math.floor(cpus().length / 2))
 console.log(`Running tests with concurrency: ${CONCURRENCY}`)
 
-async function testPage (t, testCasePath, expectedCookieNotice, expectedScrollBlocking, unsupportedBrowser) {
+async function testPage (t, testCasePath, expectedCookieNotice, expectedScrollBlocking, problematicOverlay, unsupportedBrowser) {
   const url = pathToFileURL(path.join(import.meta.dirname, 'data', testCasePath, 'index.html')).href
   const r = await checkPage({ url, hostOverride: testCasePath, blockNonHttpRequests: false, ...args })
 
@@ -68,6 +68,15 @@ async function testPage (t, testCasePath, expectedCookieNotice, expectedScrollBl
     }
   })
 
+  await t.test('problematic overlay detection', async (t) => {
+    if (problematicOverlay === undefined) {
+      t.todo('problematic overlay test ignored')
+    } else {
+      t.assert.strictEqual(r.problematicOverlay, problematicOverlay,
+        `expected problematic overlay result [${problematicOverlay}] did not match detected result [${r.problematicOverlay}]`)
+    }
+  })
+
   await t.test('unsupported browser detection', async (t) => {
     if (unsupportedBrowser === undefined) {
       t.todo('unsupported browser test ignored')
@@ -79,82 +88,82 @@ async function testPage (t, testCasePath, expectedCookieNotice, expectedScrollBl
 }
 
 const testCases = [
-  ['2021.rca.ac.uk', ['fOBTu1EHcX9tzkrWM343dsu2kqDUM9w+cMbTc5tm2oc=', 1], false, false],
-  ['abxxx.com', undefined, false, false],
-  ['bongacams.com', undefined, false, false],
-  ['brave.com', undefined, false, false],
-  ['cam4.com', ['O+Y60jG333dyHi6a3W1ZodZ7phKLk1Pr0SzhRHcKSps=', 1], false, false],
-  ['cleveradvertising.com', undefined, false, false],
-  ['copilot.microsoft.com', undefined, false, false],
-  ['docs.base.org', ['n7VghBvQo9fKfh5nqf8XLRdgA5KpZc2xjjIla8XHO+k=', 1], false, false],
-  ['drpc.org', ['59blMPXMrimFarphox8PzbXUl7EGzBkqQXlb2DjMJYU=', 1], false, false],
-  ['euronews.com', ['00Qf2C8vDmh5NYlIspQWh06S9rkUgq37TTrzAP+Odtg=', 3], false, false],
-  ['fellou.ai', ['V9lzT6lt/awn/TLYKFlhRXSqolxZvA0nu2Ld5LL3Gkw=', 1], false, false],
-  ['fortune.com', ['a1+3zJekpAmX/usMwCHTBbpo/osoiNAJpGCKuOBzoLE=', 1], false, false],
-  ['freevideo.cz', undefined, false, false],
-  ['github.com', undefined, false, false],
-  ['goibibo.com', undefined, false, false],
-  ['goodreads.com', undefined, false, false],
-  ['gostateparks.hawaii.gov', ['JBYwuwip4exVrQIqPUVGz+FWrjnVqwLj8vqq8TXAGs0=', 1], false, false],
-  ['jamieoliver.com', undefined, false, false],
-  ['jetsmart.com', undefined, false, false],
-  ['liu.se', undefined, false, false],
-  ['login.libero.it', ['EFDuHT+cKspFIMwPpsLit5MBkADL4cFifJSluFLUu6k=', 1], false, false],
-  ['mamba.ru', ['3Cyijp+TBuq8kMOT+yFakpK3GUdgBw3dH5M9x5gLbok=', 2], false, false],
-  ['massagerepublic.com', undefined, false, false],
-  ['moovitapp.com', ['yHJeNokduuywPXOjaF6MP9CJ4CBlF+X2H2u28UzLU6Y=', 2], false, false],
-  ['myworldfix.com', undefined, false, false],
-  ['nordarun.com', ['3hfzlWrqxNkDKbXjcST9vWASCuPWUfA1e41DXZMZ82o=', 3], false, false],
-  ['opensource.fb.com', ['+5qjgLXR5vQPllW7bnKVkb97tTv4xG8TdAHJXmhiH2E=', 1], false, false],
-  ['pleo.io', ['DRv+MeADAubtGiWXFF9agr8Wk9IkZmCZEoUVvK3CqAs=', 1], false, false],
-  ['primor.eu', ['Gp7z9GqoTBMAwsgh9GKMrcNpQtXY+LCzL6miyu9TvdQ=', 3], false, false],
-  ['privatekeys.pw', ['UCeiNrGF2DKp4gRogdcWQlWSrKi93/o6SsJkFpAb20U=', 1], false, false],
-  ['publicboard.edsby.com', undefined, false, true],
-  ['sendgrid.com', ['WJ1cN7pc6ZMZkOUS+7qmrTn+AtlUMLKZONI8/eVhddc=', 1], false, false],
-  ['stripchatgirls.com', ['O87YRCJw7yJGJVXqcPcWzgCuEFcva+67/ZChFxR0ULk=', 1], false, false],
-  ['supabase.com', ['fyNq/gQyR53P46zGnFaQmzAcXthZrNTPgpjE5Qp+coE=', 2], false, false],
-  ['tabelog.com', undefined, false, false],
-  ['temporal.cloud', ['bMYtB8cqUekB8ICfqzhjKDjkvqLxMMrfVEJsH55J+Pc=', 1], false, false],
-  ['temporal.io', ['yOY8MZfiQ7cLtdQNOHeOgGlYP6AfZrRRmeZyjCLDIp4=', 1], false, false],
-  ['videosdemadurasx.com', undefined, false, false],
-  ['vine.co', undefined, false, false],
-  ['voximplant.com', ['eibP8jYZYDWd1gOydbPONk71HShOp8TeCxdcrY37weI=', 1], false, false],
-  ['withpersona.com', ['BttgC24/jLdzla0v9kPROTNRLx/guLNXvIJQcGlX0+g=', 2], false, false],
-  ['worldoftanks.eu', undefined, false, false],
-  ['www.arnotts.com', ['+/BFJe+enU6qj0ZxCjZRR54Nvc1UHk4dSJ5othAycE0=', 1], false, false],
-  ['www.asdatyres.co.uk', ['Qc9jfsaR6bbwRxt3Zgy7TmZpBjKPAOFCTf3D3ddzYoc=', 1], false, false],
-  ['www.ashemaletube.com', undefined, false, false],
-  ['www.epiphone.com', ['xBn4GTL8C3TLWkLdf1iDPXXSWC0Y/QfnTmr6M5bK4sI=', 1], false, false],
-  ['www.escort.club', undefined, false, false],
-  ['www.finance-magazin.de', ['jA+itzKHMdXEReaEUaNOKbEWnuzTajy8UqdzzfWI1Po=', 3], false, false],
-  ['www.finn.no', ['YLqo3cOckIQCrg0TY5cvEVYKVjguJDBcJTRdZsrrLDM=', 1], true, false],
-  ['www.france24.com', ['36uVkl4m+wUMPRZrHDdZDnrnK6/lz+ETsDoZArrbeNY=', 3], false, false],
-  ['www.g-star.com', ['tElFyJc98b8e1eIcMu7T4AyOR6b0mIaNvOAU6wwcPdU=', 2], false, false],
-  ['www.gov.br', ['2jP5ZkNOLK185bl96B/kXsg1SScsGjOzbSdy8VdLnZg=', 2], false, false],
-  ['www.heise.de', ['ILZYIEAu9Dh3pcdm7FS9EhQ3RKU8z7cfKVLp3h3NchI=', 1], true, false],
-  ['www.intelligems.io', undefined, false, false],
-  ['www.kafijasdraugs.lv', ['PNqCk+fE2Az2o+hzvNXiqe+HHWh23mmAzrZNd9zeHzo=', 2], false, false],
-  ['www.kellanova.com', ['aZxeT/PGvgW5wcPMCkeXGJlXw88lC/GfEEJY+0bUXBU=', 2], false, false],
-  ['www.lyrath.com', ['k2lGP0argaS6Iu+9XWZxDgNim2kFpq6JQGy5o7b6BHc=', 1], false, false],
-  ['www.meld.io', ['SrMn/AlL+1vb9Ob9MneGIdHzuDVdK0QzOfBpLbBatCQ=', 1], false, false],
-  ['www.meteomatics.com', ['6Ps/8TBEuIaGYIyKkGiWhCO06jOtFFBwZkpvt2MES5w=', 1], false, false],
-  ['www.mytime.mk', ['tOFLQjiyjNl9dtaePfbDtKWouVwXBY7lxmakEVQK208=', 1], true, false],
-  ['www.myway.com', undefined, false, false],
-  ['www.nerdwallet.com', undefined, false, false],
-  ['www.newsflare.com', ['A1REDzJ4zCkWa3pUNGFFmChRUyObXuXONKwF/QA1s7A=', 1], false, false],
-  ['www.northcoast.com', ['agltnUgo6/v/bKDMe116cck0BQqmYn17Ma8G1R3ZVm0=', 1], false, false],
-  ['www.outdooractive.com', ['TFZ0mmoCPPMzbEMynO5ldHJqTTjto4jXA4SXpwFD5mU=', 1], false, false],
-  ['www.pibank.com', ['/R/SbX32j2pKrsl33C+CGURTgOWeC2kNe1PW9VMh098=', 1], false, false],
-  ['www.plannedparenthood.org', ['MTBXRXupEgImCJ6PURX2LZ3fqceWDu2mmZDqB8pCj5w=', 1], false, false],
-  ['www.promod.fr', undefined, true, false],
-  ['www.rebelmouse.com', undefined, false, false],
-  ['www.refinery29.com', ['+bdOjXMDngBgmjcnMxUSgSVBw9y0YCBZaGlrmJe9HF8=', 1], true, false],
-  ['www.rfi.fr', ['t8byePWKBspylgvPO568uEjwI4czAJ0ujhE3XfS2ur4=', 3], false, false],
-  ['www.ryanair.com', ['1aXesNIeRzje8VpkE6hjGYCeBYPk1nnVpNynB1YCQY8=', 1], false, false],
-  ['www.unilad.com', ['/PXxl4ws/HZVHq2wBHQVO9PtKFNSHHrl1wfCfmoaZ9w=', 1], true, false],
-  ['www.wardvillage.com', ['RiDcFOm/YVgP1DuCErIfD5/Va9KAXFoem+Pdcn2qZLA=', 1], false, false],
-  ['www.whatnot.com', undefined, false, false],
-  ['zora.co', ['ZQGVsHwN2dm4XfAmUeYQeV2b0eJxM45CFdQtDyeVjU0=', 2], false, false]
+  ['2021.rca.ac.uk', ['fOBTu1EHcX9tzkrWM343dsu2kqDUM9w+cMbTc5tm2oc=', 1], false, false, false],
+  ['abxxx.com', undefined, false, false, false],
+  ['bongacams.com', undefined, false, false, false],
+  ['brave.com', undefined, false, false, false],
+  ['cam4.com', ['O+Y60jG333dyHi6a3W1ZodZ7phKLk1Pr0SzhRHcKSps=', 1], false, false, false],
+  ['cleveradvertising.com', undefined, false, false, false],
+  ['copilot.microsoft.com', undefined, false, false, false],
+  ['docs.base.org', ['n7VghBvQo9fKfh5nqf8XLRdgA5KpZc2xjjIla8XHO+k=', 1], false, false, false],
+  ['drpc.org', ['59blMPXMrimFarphox8PzbXUl7EGzBkqQXlb2DjMJYU=', 1], false, false, false],
+  ['euronews.com', ['00Qf2C8vDmh5NYlIspQWh06S9rkUgq37TTrzAP+Odtg=', 3], false, false, false],
+  ['fellou.ai', ['V9lzT6lt/awn/TLYKFlhRXSqolxZvA0nu2Ld5LL3Gkw=', 1], false, false, false],
+  ['fortune.com', ['a1+3zJekpAmX/usMwCHTBbpo/osoiNAJpGCKuOBzoLE=', 1], false, false, false],
+  ['freevideo.cz', undefined, false, false, false],
+  ['github.com', undefined, false, false, false],
+  ['goibibo.com', undefined, false, false, false],
+  ['goodreads.com', undefined, false, false, false],
+  ['gostateparks.hawaii.gov', ['JBYwuwip4exVrQIqPUVGz+FWrjnVqwLj8vqq8TXAGs0=', 1], false, false, false],
+  ['jamieoliver.com', undefined, false, false, false],
+  ['jetsmart.com', undefined, false, false, false],
+  ['liu.se', undefined, false, false, false],
+  ['login.libero.it', ['EFDuHT+cKspFIMwPpsLit5MBkADL4cFifJSluFLUu6k=', 1], false, false, false],
+  ['mamba.ru', ['3Cyijp+TBuq8kMOT+yFakpK3GUdgBw3dH5M9x5gLbok=', 2], false, false, false],
+  ['massagerepublic.com', undefined, false, false, false],
+  ['moovitapp.com', ['yHJeNokduuywPXOjaF6MP9CJ4CBlF+X2H2u28UzLU6Y=', 2], false, false, false],
+  ['myworldfix.com', undefined, false, true, false],
+  ['nordarun.com', ['3hfzlWrqxNkDKbXjcST9vWASCuPWUfA1e41DXZMZ82o=', 3], false, false, false],
+  ['opensource.fb.com', ['+5qjgLXR5vQPllW7bnKVkb97tTv4xG8TdAHJXmhiH2E=', 1], false, false, false],
+  ['pleo.io', ['DRv+MeADAubtGiWXFF9agr8Wk9IkZmCZEoUVvK3CqAs=', 1], false, true, false],
+  ['primor.eu', ['Gp7z9GqoTBMAwsgh9GKMrcNpQtXY+LCzL6miyu9TvdQ=', 3], false, false, false],
+  ['privatekeys.pw', ['UCeiNrGF2DKp4gRogdcWQlWSrKi93/o6SsJkFpAb20U=', 1], false, false, false],
+  ['publicboard.edsby.com', undefined, false, false, true],
+  ['sendgrid.com', ['WJ1cN7pc6ZMZkOUS+7qmrTn+AtlUMLKZONI8/eVhddc=', 1], false, false, false],
+  ['stripchatgirls.com', ['O87YRCJw7yJGJVXqcPcWzgCuEFcva+67/ZChFxR0ULk=', 1], false, false, false],
+  ['supabase.com', ['fyNq/gQyR53P46zGnFaQmzAcXthZrNTPgpjE5Qp+coE=', 2], false, false, false],
+  ['tabelog.com', undefined, false, false, false],
+  ['temporal.cloud', ['bMYtB8cqUekB8ICfqzhjKDjkvqLxMMrfVEJsH55J+Pc=', 1], false, true, false],
+  ['temporal.io', ['yOY8MZfiQ7cLtdQNOHeOgGlYP6AfZrRRmeZyjCLDIp4=', 1], false, false, false],
+  ['videosdemadurasx.com', undefined, false, false, false],
+  ['vine.co', undefined, false, false, false],
+  ['voximplant.com', ['eibP8jYZYDWd1gOydbPONk71HShOp8TeCxdcrY37weI=', 1], false, false, false],
+  ['withpersona.com', ['BttgC24/jLdzla0v9kPROTNRLx/guLNXvIJQcGlX0+g=', 2], false, false, false],
+  ['worldoftanks.eu', undefined, false, false, false],
+  ['www.arnotts.com', ['+/BFJe+enU6qj0ZxCjZRR54Nvc1UHk4dSJ5othAycE0=', 1], false, false, false],
+  ['www.asdatyres.co.uk', ['Qc9jfsaR6bbwRxt3Zgy7TmZpBjKPAOFCTf3D3ddzYoc=', 1], false, false, false],
+  ['www.ashemaletube.com', undefined, false, false, false],
+  ['www.epiphone.com', ['xBn4GTL8C3TLWkLdf1iDPXXSWC0Y/QfnTmr6M5bK4sI=', 1], false, false, false],
+  ['www.escort.club', undefined, false, false, false],
+  ['www.finance-magazin.de', ['jA+itzKHMdXEReaEUaNOKbEWnuzTajy8UqdzzfWI1Po=', 3], false, false, false],
+  ['www.finn.no', ['YLqo3cOckIQCrg0TY5cvEVYKVjguJDBcJTRdZsrrLDM=', 1], true, true, false],
+  ['www.france24.com', ['36uVkl4m+wUMPRZrHDdZDnrnK6/lz+ETsDoZArrbeNY=', 3], false, false, false],
+  ['www.g-star.com', ['tElFyJc98b8e1eIcMu7T4AyOR6b0mIaNvOAU6wwcPdU=', 2], false, false, false],
+  ['www.gov.br', ['2jP5ZkNOLK185bl96B/kXsg1SScsGjOzbSdy8VdLnZg=', 2], false, false, false],
+  ['www.heise.de', ['ILZYIEAu9Dh3pcdm7FS9EhQ3RKU8z7cfKVLp3h3NchI=', 1], true, true, false],
+  ['www.intelligems.io', undefined, false, false, false],
+  ['www.kafijasdraugs.lv', ['PNqCk+fE2Az2o+hzvNXiqe+HHWh23mmAzrZNd9zeHzo=', 2], false, false, false],
+  ['www.kellanova.com', ['aZxeT/PGvgW5wcPMCkeXGJlXw88lC/GfEEJY+0bUXBU=', 2], false, false, false],
+  ['www.lyrath.com', ['k2lGP0argaS6Iu+9XWZxDgNim2kFpq6JQGy5o7b6BHc=', 1], false, false, false],
+  ['www.meld.io', ['SrMn/AlL+1vb9Ob9MneGIdHzuDVdK0QzOfBpLbBatCQ=', 1], false, false, false],
+  ['www.meteomatics.com', ['6Ps/8TBEuIaGYIyKkGiWhCO06jOtFFBwZkpvt2MES5w=', 1], false, false, false],
+  ['www.mytime.mk', ['tOFLQjiyjNl9dtaePfbDtKWouVwXBY7lxmakEVQK208=', 1], true, true, false],
+  ['www.myway.com', undefined, false, false, false],
+  ['www.nerdwallet.com', undefined, false, false, false],
+  ['www.newsflare.com', ['A1REDzJ4zCkWa3pUNGFFmChRUyObXuXONKwF/QA1s7A=', 1], false, false, false],
+  ['www.northcoast.com', ['agltnUgo6/v/bKDMe116cck0BQqmYn17Ma8G1R3ZVm0=', 1], false, false, false],
+  ['www.outdooractive.com', ['TFZ0mmoCPPMzbEMynO5ldHJqTTjto4jXA4SXpwFD5mU=', 1], false, false, false],
+  ['www.pibank.com', ['/R/SbX32j2pKrsl33C+CGURTgOWeC2kNe1PW9VMh098=', 1], false, false, false],
+  ['www.plannedparenthood.org', ['MTBXRXupEgImCJ6PURX2LZ3fqceWDu2mmZDqB8pCj5w=', 1], false, false, false],
+  ['www.promod.fr', undefined, true, true, false],
+  ['www.rebelmouse.com', undefined, false, false, false],
+  ['www.refinery29.com', ['+bdOjXMDngBgmjcnMxUSgSVBw9y0YCBZaGlrmJe9HF8=', 1], true, true, false],
+  ['www.rfi.fr', ['t8byePWKBspylgvPO568uEjwI4czAJ0ujhE3XfS2ur4=', 3], false, false, false],
+  ['www.ryanair.com', ['1aXesNIeRzje8VpkE6hjGYCeBYPk1nnVpNynB1YCQY8=', 1], false, false, false],
+  ['www.unilad.com', ['/PXxl4ws/HZVHq2wBHQVO9PtKFNSHHrl1wfCfmoaZ9w=', 1], true, true, false],
+  ['www.wardvillage.com', ['RiDcFOm/YVgP1DuCErIfD5/Va9KAXFoem+Pdcn2qZLA=', 1], false, false, false],
+  ['www.whatnot.com', undefined, false, false, false],
+  ['zora.co', ['ZQGVsHwN2dm4XfAmUeYQeV2b0eJxM45CFdQtDyeVjU0=', 2], false, false, false]
 ]
 
 describe('Cookie consent tests', { concurrency: CONCURRENCY }, () => {
@@ -163,9 +172,9 @@ describe('Cookie consent tests', { concurrency: CONCURRENCY }, () => {
     await prepareProfile(args)
   })
 
-  for (const [testCasePath, expectedHash, expectedScrollBlocking, unsupportedBrowser] of testCases) {
+  for (const [testCasePath, expectedHash, expectedScrollBlocking, problematicOverlay, unsupportedBrowser] of testCases) {
     it(testCasePath, async (t) => {
-      await testPage(t, testCasePath, expectedHash, expectedScrollBlocking, unsupportedBrowser)
+      await testPage(t, testCasePath, expectedHash, expectedScrollBlocking, problematicOverlay, unsupportedBrowser)
     })
   }
 })


### PR DESCRIPTION
In cookiecrumbler, we determine if there is a problematic overlay on a page as part of the scroll blocking detection.

In my cookie-notice-fixer tool, I use cookiecrumbler to verify that a suggested fix successfully hides a cookie notice. However, the suggested fix often does not remove the overlay that belongs with the cookie notice on a site. If the problematic overlay (which we already check in cookiecrumbler) is made visible in the reports and API, then it can be used in my project to prevent false positives.

There may be a performance hit, as the"findProblematicOverlay" method is called on every site now. 